### PR TITLE
Upgrade to ppxlib.0.14.0

### DIFF
--- a/ppx_bench.opam
+++ b/ppx_bench.opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml"           {>= "4.04.2"}
   "ppx_inline_test" {>= "v0.14" & < "v0.15"}
   "dune"            {>= "2.0.0"}
-  "ppxlib"          {>= "0.11.0"}
+  "ppxlib"          {>= "0.14.0"}
 ]
 synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
 description: "

--- a/src/ppx_bench.ml
+++ b/src/ppx_bench.ml
@@ -128,7 +128,7 @@ let expand_bench_module ~loc ~path name_suffix name m =
   apply_to_descr_bench
     path "add_bench_module" loc ~inner_loc:m.pmod_loc None ?name_suffix name
     (pexp_fun ~loc Nolabel None (punit ~loc)
-       (pexp_letmodule ~loc (Located.mk ~loc "M")
+       (pexp_letmodule ~loc (Located.mk ~loc (Some "M"))
           m
           (eunit ~loc)))
 


### PR DESCRIPTION
The next release of ppxlib will use the 4.10 AST internally. This PR makes ppx_bench compatible with this new version. Probably worth waiting for the new release before merging this!