### PR TITLE
Stop using [Ppxlib.File_path].

### DIFF
--- a/src/ppx_bench.ml
+++ b/src/ppx_bench.ml
@@ -49,7 +49,7 @@ let maybe_drop loc code =
 ;;
 
 let descr (loc : Location.t) ?(inner_loc = loc) () =
-  let filename = File_path.get_default_path loc in
+  let filename = loc.loc_start.pos_fname in
   let line = loc.loc_start.pos_lnum in
   let start_pos = loc.loc_start.pos_cnum - loc.loc_start.pos_bol in
   let end_pos = inner_loc.Location.loc_end.pos_cnum - loc.loc_start.pos_bol in


### PR DESCRIPTION
I've rebased @ceastlund's [patch for compatibility with `ppxlib` `main`](https://github.com/janestreet/ppx_bench/pull/4) over the latest release branch. His PR message was:

> The tip of Ppxlib removes the File_path submodule. This patch fixes ppx_bench for that change.

Do you want me to add a changelog entry as well?